### PR TITLE
Adjust sidebar logo scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -758,6 +758,13 @@ select.form-control {
     border-bottom: 1px solid var(--color-border);
 }
 
+.sidebar-logo {
+    display: block;
+    max-height: 90px;
+    width: auto;
+    object-fit: contain;
+}
+
 .sidebar-header h2 {
     margin: 0;
     color: var(--color-primary);


### PR DESCRIPTION
## Summary
- update the `.sidebar-logo` rule to use a max-height with automatic width and contain fit for better scaling

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68dcddaed3148331922fc6f40da6a556