### PR TITLE
Add mobile sidebar toggle controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,7 @@ function initializeApp() {
 
     // Setup navigation
     setupNavigation();
+    setupSidebarToggle();
 
     // Initialize all sections
     initializeOverview();
@@ -184,6 +185,48 @@ function setupNavigation() {
             this.classList.add('active');
         });
     });
+}
+
+function setupSidebarToggle() {
+    const sidebar = document.querySelector('.sidebar');
+    const toggleButton = document.querySelector('.sidebar-toggle');
+    const overlay = document.querySelector('.sidebar-overlay');
+
+    if (!sidebar || !toggleButton || !overlay) {
+        return;
+    }
+
+    const openSidebar = () => {
+        sidebar.classList.add('open');
+        overlay.classList.add('active');
+        toggleButton.setAttribute('aria-expanded', 'true');
+    };
+
+    const closeSidebar = () => {
+        sidebar.classList.remove('open');
+        overlay.classList.remove('active');
+        toggleButton.setAttribute('aria-expanded', 'false');
+    };
+
+    const toggleSidebar = () => {
+        if (sidebar.classList.contains('open')) {
+            closeSidebar();
+        } else {
+            openSidebar();
+        }
+    };
+
+    toggleButton.addEventListener('click', toggleSidebar);
+    overlay.addEventListener('click', closeSidebar);
+
+    const handleResize = () => {
+        if (window.innerWidth >= 769) {
+            closeSidebar();
+        }
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
 }
 
 function switchSection(sectionName) {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <body>
 
   <!-- Sidebar -->
-  <aside class="sidebar">
+  <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
       <h2>Construction AI</h2>
       <div style="color:var(--color-text-secondary);font-size:12px;">Pertamina Dashboard</div>
@@ -43,6 +43,15 @@
       </a>
     </nav>
   </aside>
+
+  <button class="sidebar-toggle" type="button" aria-controls="sidebar" aria-expanded="false">
+    <span class="sr-only">Toggle navigasi</span>
+    <span class="sidebar-toggle__bar" aria-hidden="true"></span>
+    <span class="sidebar-toggle__bar" aria-hidden="true"></span>
+    <span class="sidebar-toggle__bar" aria-hidden="true"></span>
+  </button>
+
+  <div class="sidebar-overlay" aria-hidden="true"></div>
 
   <!-- Main -->
   <main class="main-content">

--- a/style.css
+++ b/style.css
@@ -747,10 +747,67 @@ select.form-control {
     height: 100vh;
     background: var(--color-surface);
     border-right: 1px solid var(--color-border);
-    z-index: 100;
+    z-index: 200;
     display: flex;
     flex-direction: column;
     box-shadow: var(--shadow-md);
+    transform: translateX(0);
+    transition: transform var(--duration-normal) var(--ease-standard);
+}
+
+.sidebar-toggle {
+    position: fixed;
+    top: var(--space-16);
+    left: var(--space-16);
+    z-index: 250;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 6px;
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-full);
+    border: none;
+    background: var(--color-primary);
+    color: var(--color-btn-primary-text);
+    cursor: pointer;
+    box-shadow: var(--shadow-md);
+    transition: background var(--duration-fast) var(--ease-standard), transform var(--duration-fast) var(--ease-standard);
+}
+
+.sidebar-toggle:hover {
+    background: var(--color-primary-hover);
+}
+
+.sidebar-toggle:active {
+    transform: scale(0.96);
+    background: var(--color-primary-active);
+}
+
+.sidebar-toggle__bar {
+    display: block;
+    width: 20px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+}
+
+.sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(var(--color-slate-900-rgb), 0.45);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity var(--duration-normal) var(--ease-standard), visibility var(--duration-normal) var(--ease-standard);
+    z-index: 150;
+}
+
+.sidebar-overlay.active {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .sidebar-header {
@@ -1711,9 +1768,8 @@ tr:hover td {
 @media (max-width: 768px) {
     .sidebar {
         transform: translateX(-100%);
-        transition: transform var(--duration-normal) var(--ease-standard);
     }
-    
+
     .sidebar.open {
         transform: translateX(0);
     }
@@ -1755,5 +1811,12 @@ tr:hover td {
     .table-container {
         overflow-x: scroll;
         -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (min-width: 769px) {
+    .sidebar-toggle,
+    .sidebar-overlay {
+        display: none;
     }
 }


### PR DESCRIPTION
## Summary
- add a hamburger toggle button and overlay to the layout so the sidebar can be opened on small screens
- style the sidebar toggle, overlay, and responsive sidebar transitions for mobile and desktop breakpoints
- implement JavaScript to handle toggle interactions, overlay clicks, and resize events to keep the sidebar state in sync

## Testing
- Manual testing: not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68dce00d37f48331a86aa72abea8da02